### PR TITLE
Add categories to books list

### DIFF
--- a/content/books.md
+++ b/content/books.md
@@ -9,48 +9,48 @@ This page tracks books I have finished and books that I would like to read somed
 
 ## Finished
 
-- [Tribe of Mentors](https://en.wikipedia.org/wiki/Tribe_of_Mentors) by Tim Ferriss
-- [The Systems Mindset](https://en.wikipedia.org/wiki/Sam_Carpenter) by Sam Carpenter
-- [A More Beautiful Question](https://en.wikipedia.org/wiki/Warren_Berger) by Warren Berger
-- [Program or Be Programmed: Ten Commands for a Digital Age](https://en.wikipedia.org/wiki/Douglas_Rushkoff#Books) by Douglas Rushkoff
-- [What the Dog Saw](https://en.wikipedia.org/wiki/Malcolm_Gladwell) by Malcolm Gladwell
-- [Man's Search for Meaning](https://en.wikipedia.org/wiki/Man%27s_Search_for_Meaning) by Viktor Frankl
-- [Fooled by Randomness](https://en.wikipedia.org/wiki/Nassim_Nicholas_Taleb#Bibliography) by Nassim Nicholas Taleb
-- [Atomic Habits](https://en.wikipedia.org/wiki/James_Clear) by James Clear
-- [Discover Your Inner Economist](https://en.wikipedia.org/wiki/Tyler_Cowen#Bibliography) by Tyler Cowen
-- [Your Memory](https://en.wikipedia.org/wiki/Kenneth_L._Higbee) by Kenneth L. Higbee
-- [Zero to One: Notes on Startups, or How to Build the Future](https://en.wikipedia.org/wiki/Zero_to_One) by Peter Thiel and Blake Masters
-- [Meditations](https://en.wikipedia.org/wiki/Meditations) by Marcus Aurelius
-- [Brave New World](https://en.wikipedia.org/wiki/Brave_New_World) by Aldous Huxley
-- [What I Talk About When I Talk About Running](https://en.wikipedia.org/wiki/What_I_Talk_About_When_I_Talk_About_Running) by Haruki Murakami
-- [Napoleon: A Life](https://en.wikipedia.org/wiki/Andrew_Roberts_(historian)) by Andrew Roberts
-- [Way of the Warrior Kid: From Wimpy to Warrior the Navy SEAL Way](https://en.wikipedia.org/wiki/Jocko_Willink) by Jocko Willink
-- [Make It Stick](https://en.wikipedia.org/wiki/Make_It_Stick) by Peter C. Brown, Henry L. Roediger III, and Mark A. McDaniel
-- [The Four Filters Invention of Warren Buffett and Charlie Munger](https://en.wikipedia.org/wiki/Warren_Buffett) by Bud Labitan
-- [The Think Big Manifesto](https://en.wikipedia.org/wiki/Michael_Port) by Michael Port
-- [The Sense of Style](https://en.wikipedia.org/wiki/The_Sense_of_Style) by Steven Pinker
-- [Writing Tools](https://en.wikipedia.org/wiki/Roy_Peter_Clark) by Roy Peter Clark
-- [Bird by Bird: Some Instructions on Writing and Life](https://en.wikipedia.org/wiki/Bird_by_Bird) by Anne Lamott
-- [Zone to Win](https://en.wikipedia.org/wiki/Geoffrey_Moore) by Geoffrey A. Moore
-- [Homo Deus](https://en.wikipedia.org/wiki/Homo_Deus:_A_Brief_History_of_Tomorrow) by Yuval Noah Harari
-- [The Power of No](https://en.wikipedia.org/wiki/James_Altucher#Books) by James Altucher and Claudia Azula Altucher
-- [The Subtle Art of Not Giving a F*ck](https://en.wikipedia.org/wiki/The_Subtle_Art_of_Not_Giving_a_F*ck) by Mark Manson
-- [Surely You're Joking, Mr. Feynman!](https://en.wikipedia.org/wiki/Surely_You%27re_Joking,_Mr._Feynman!) by Richard Feynman and Ralph Leighton
-- [The Organized Mind: Thinking Straight in the Age of Information Overload](https://en.wikipedia.org/wiki/Daniel_J._Levitin#Books) by Daniel J. Levitin
-- [Complexity: A Guided Tour](https://en.wikipedia.org/wiki/Complexity:_A_Guided_Tour) by Melanie Mitchell
-- [The Daily Stoic](https://en.wikipedia.org/wiki/Ryan_Holiday#Books) by Ryan Holiday and Stephen Hanselman
-- [Marc's Mission](https://en.wikipedia.org/wiki/Jocko_Willink#Books) by Jocko Willink
-- [Grit: The Power of Passion and Perseverance](https://en.wikipedia.org/wiki/Grit_(book)) by Angela Duckworth
-- [Pomodoro Technique Illustrated](https://en.wikipedia.org/wiki/Pomodoro_Technique) by Staffan Noteberg
-- [Ethics](https://en.wikipedia.org/wiki/Ethics_(Spinoza)) by Baruch Spinoza
-- [The Checklist Manifesto](https://en.wikipedia.org/wiki/The_Checklist_Manifesto) by Atul Gawande
-- [Lying](https://en.wikipedia.org/wiki/Sam_Harris#Writings) by Sam Harris
-- [The Drunkard's Walk: How Randomness Rules Our Lives](https://en.wikipedia.org/wiki/The_Drunkard%27s_Walk) by Leonard Mlodinow
-- [The Pleasures and Sorrows of Work](https://en.wikipedia.org/wiki/Alain_de_Botton#Works) by Alain de Botton
-- [Understand](https://en.wikipedia.org/wiki/Ted_Chiang_bibliography#Short_fiction) by Ted Chiang
+- [Tribe of Mentors](https://en.wikipedia.org/wiki/Tribe_of_Mentors) by Tim Ferriss — Self-help
+- [The Systems Mindset](https://en.wikipedia.org/wiki/Sam_Carpenter) by Sam Carpenter — Self-help
+- [A More Beautiful Question](https://en.wikipedia.org/wiki/Warren_Berger) by Warren Berger — Self-help
+- [Program or Be Programmed: Ten Commands for a Digital Age](https://en.wikipedia.org/wiki/Douglas_Rushkoff#Books) by Douglas Rushkoff — Culture
+- [What the Dog Saw](https://en.wikipedia.org/wiki/Malcolm_Gladwell) by Malcolm Gladwell — Culture
+- [Man's Search for Meaning](https://en.wikipedia.org/wiki/Man%27s_Search_for_Meaning) by Viktor Frankl — Philosophy
+- [Fooled by Randomness](https://en.wikipedia.org/wiki/Nassim_Nicholas_Taleb#Bibliography) by Nassim Nicholas Taleb — Culture
+- [Atomic Habits](https://en.wikipedia.org/wiki/James_Clear) by James Clear — Self-help
+- [Discover Your Inner Economist](https://en.wikipedia.org/wiki/Tyler_Cowen#Bibliography) by Tyler Cowen — Business
+- [Your Memory](https://en.wikipedia.org/wiki/Kenneth_L._Higbee) by Kenneth L. Higbee — Science
+- [Zero to One: Notes on Startups, or How to Build the Future](https://en.wikipedia.org/wiki/Zero_to_One) by Peter Thiel and Blake Masters — Business
+- [Meditations](https://en.wikipedia.org/wiki/Meditations) by Marcus Aurelius — Philosophy
+- [Brave New World](https://en.wikipedia.org/wiki/Brave_New_World) by Aldous Huxley — Fiction
+- [What I Talk About When I Talk About Running](https://en.wikipedia.org/wiki/What_I_Talk_About_When_I_Talk_About_Running) by Haruki Murakami — Memoir
+- [Napoleon: A Life](https://en.wikipedia.org/wiki/Andrew_Roberts_(historian)) by Andrew Roberts — History
+- [Way of the Warrior Kid: From Wimpy to Warrior the Navy SEAL Way](https://en.wikipedia.org/wiki/Jocko_Willink) by Jocko Willink — Self-help
+- [Make It Stick](https://en.wikipedia.org/wiki/Make_It_Stick) by Peter C. Brown, Henry L. Roediger III, and Mark A. McDaniel — Self-help
+- [The Four Filters Invention of Warren Buffett and Charlie Munger](https://en.wikipedia.org/wiki/Warren_Buffett) by Bud Labitan — Business
+- [The Think Big Manifesto](https://en.wikipedia.org/wiki/Michael_Port) by Michael Port — Self-help
+- [The Sense of Style](https://en.wikipedia.org/wiki/The_Sense_of_Style) by Steven Pinker — Writing
+- [Writing Tools](https://en.wikipedia.org/wiki/Roy_Peter_Clark) by Roy Peter Clark — Writing
+- [Bird by Bird: Some Instructions on Writing and Life](https://en.wikipedia.org/wiki/Bird_by_Bird) by Anne Lamott — Writing
+- [Zone to Win](https://en.wikipedia.org/wiki/Geoffrey_Moore) by Geoffrey A. Moore — Business
+- [Homo Deus](https://en.wikipedia.org/wiki/Homo_Deus:_A_Brief_History_of_Tomorrow) by Yuval Noah Harari — Philosophy
+- [The Power of No](https://en.wikipedia.org/wiki/James_Altucher#Books) by James Altucher and Claudia Azula Altucher — Self-help
+- [The Subtle Art of Not Giving a F*ck](https://en.wikipedia.org/wiki/The_Subtle_Art_of_Not_Giving_a_F*ck) by Mark Manson — Self-help
+- [Surely You're Joking, Mr. Feynman!](https://en.wikipedia.org/wiki/Surely_You%27re_Joking,_Mr._Feynman!) by Richard Feynman and Ralph Leighton — Memoir
+- [The Organized Mind: Thinking Straight in the Age of Information Overload](https://en.wikipedia.org/wiki/Daniel_J._Levitin#Books) by Daniel J. Levitin — Self-help
+- [Complexity: A Guided Tour](https://en.wikipedia.org/wiki/Complexity:_A_Guided_Tour) by Melanie Mitchell — Science
+- [The Daily Stoic](https://en.wikipedia.org/wiki/Ryan_Holiday#Books) by Ryan Holiday and Stephen Hanselman — Philosophy
+- [Marc's Mission](https://en.wikipedia.org/wiki/Jocko_Willink#Books) by Jocko Willink — Self-help
+- [Grit: The Power of Passion and Perseverance](https://en.wikipedia.org/wiki/Grit_(book)) by Angela Duckworth — Self-help
+- [Pomodoro Technique Illustrated](https://en.wikipedia.org/wiki/Pomodoro_Technique) by Staffan Noteberg — Self-help
+- [Ethics](https://en.wikipedia.org/wiki/Ethics_(Spinoza)) by Baruch Spinoza — Philosophy
+- [The Checklist Manifesto](https://en.wikipedia.org/wiki/The_Checklist_Manifesto) by Atul Gawande — Self-help
+- [Lying](https://en.wikipedia.org/wiki/Sam_Harris#Writings) by Sam Harris — Philosophy
+- [The Drunkard's Walk: How Randomness Rules Our Lives](https://en.wikipedia.org/wiki/The_Drunkard%27s_Walk) by Leonard Mlodinow — Science
+- [The Pleasures and Sorrows of Work](https://en.wikipedia.org/wiki/Alain_de_Botton#Works) by Alain de Botton — Culture
+- [Understand](https://en.wikipedia.org/wiki/Ted_Chiang_bibliography#Short_fiction) by Ted Chiang — Fiction
 
 ## Books that I would like to read one day
 
-- [Hagakure](https://en.wikipedia.org/wiki/Hagakure) by Yamamoto Tsunetomo
-- [Mirrorshades: The Cyberpunk Anthology](https://en.wikipedia.org/wiki/Mirrorshades) edited by Bruce Sterling
+- [Hagakure](https://en.wikipedia.org/wiki/Hagakure) by Yamamoto Tsunetomo — History
+- [Mirrorshades: The Cyberpunk Anthology](https://en.wikipedia.org/wiki/Mirrorshades) edited by Bruce Sterling — Fiction
 


### PR DESCRIPTION
## Summary
- annotate each book with a category such as `Self-help`, `Business`, or `Philosophy`
- label the 'Books I would like to read' section entries with categories

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68481b935b0c832eaff8bf7871c28f3c