### PR TITLE
Add Art section with artist profiles

### DIFF
--- a/content/AstralPostcards.md
+++ b/content/AstralPostcards.md
@@ -1,0 +1,7 @@
+---
+title: AstralPostcards
+description: dreamy scenes from beyond the stars
+---
+[Visit on X](https://x.com/AstralPostcards/media)
+
+Cosmic vistas and hazy light, mailed from the outer reaches of imagination.

--- a/content/BreezeChai.md
+++ b/content/BreezeChai.md
@@ -1,0 +1,7 @@
+---
+title: BreezeChai
+description: slow moments steeped in pastel warmth
+---
+[Visit on X](https://x.com/BreezeChai)
+
+Soft colors and quiet moods; images that feel like a calm breath.

--- a/content/Macbaconai.md
+++ b/content/Macbaconai.md
@@ -1,0 +1,7 @@
+---
+title: Macbaconai
+description: AI collages splashed in neon and humor
+---
+[Visit on X](https://x.com/Macbaconai)
+
+Short bursts of digital mischief, each image a wink to the viewer.

--- a/content/MaxVOAO.md
+++ b/content/MaxVOAO.md
@@ -1,0 +1,7 @@
+---
+title: MaxVOAO
+description: cinematic fragments from an alternate universe
+---
+[Visit on X](https://x.com/MaxVOAO)
+
+Each post feels like a frame from a forgotten film, heavy on atmosphere, light on captions.

--- a/content/art.md
+++ b/content/art.md
@@ -1,0 +1,10 @@
+---
+title: Art
+description: A scrapbook of digital artists I follow
+---
+A short collection of accounts showcasing playful, dreamlike visuals.
+
+- [[Macbaconai]] — A swirl of AI-driven color and whimsical experiments.
+- [[MaxVOAO]] — Scenes that feel like stills from a lost sci-fi reel.
+- [[AstralPostcards]] — Postcards from cosmic daydreams, washed in nostalgia.
+- [[BreezeChai]] — Gentle hues and quiet moments steeped like tea.


### PR DESCRIPTION
## Summary
- add an Art page listing several X accounts
- create pages for Macbaconai, MaxVOAO, AstralPostcards, and BreezeChai with brief descriptions

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b850dab10832e95be82e6f71ad679