### PR TITLE
Add Art section with artist profiles

### DIFF
--- a/content/art.md
+++ b/content/art.md
@@ -1,0 +1,10 @@
+---
+title: Art
+description: A scrapbook of digital artists I follow
+---
+A short collection of accounts showcasing playful, dreamlike visuals.
+
+- [@Macbaconai](https://x.com/Macbaconai) — A swirl of AI-driven color and whimsical experiments.
+- [@MaxVOAO](https://x.com/MaxVOAO) — Scenes that feel like stills from a lost sci-fi reel.
+- [@AstralPostcards](https://x.com/AstralPostcards/media) — Postcards from cosmic daydreams, washed in nostalgia.
+- [@BreezeChai](https://x.com/BreezeChai) — Gentle hues and quiet moments steeped like tea.


### PR DESCRIPTION
## Summary
- consolidate all artist info on a single `Art` page
- remove individual artist pages

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b850dab10832e95be82e6f71ad679